### PR TITLE
feat: Docker test environment + CI/CD pipeline (Phase 5)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.pytest_cache
+.coverage
+htmlcov/
+__pycache__
+*.pyc
+*.egg-info
+.venv
+node_modules
+frontend/node_modules
+*.db

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Python Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install -e ".[dev,server]"
+
+      - name: Run tests
+        run: pytest -v --tb=short --cov=infra_auditor --cov=aggregator --cov-report=xml
+
+      - name: Upload coverage
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          file: coverage.xml
+        continue-on-error: true
+
+  frontend:
+    name: Frontend Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install & Build
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+  docker:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    needs: [test, frontend]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Aggregator image
+        run: docker build -f Dockerfile.aggregator -t infra-auditor-aggregator .
+
+      - name: Build Frontend image
+        run: docker build -f Dockerfile.frontend -t infra-auditor-frontend .
+
+      - name: Build Agent image (Ubuntu 22.04)
+        run: docker build -f Dockerfile.agent --build-arg BASE_IMAGE=ubuntu:22.04 -t infra-auditor-agent-ubuntu22 .
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [test, frontend, docker]
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 .coverage
 htmlcov/
 *.egg
+*.db
+node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to infra-auditor
+
+## 개발 환경 설정
+
+```bash
+git clone https://github.com/ecmoce/infra-auditor.git
+cd infra-auditor
+pip install -e ".[dev,server]"
+cd frontend && npm ci && cd ..
+```
+
+## 브랜치 전략
+
+- `main`: 안정 브랜치
+- `feature/*`: 기능 개발
+- `fix/*`: 버그 수정
+
+## 커밋 컨벤션
+
+[Conventional Commits](https://www.conventionalcommits.org/) 형식:
+
+```
+feat: 새 기능 추가
+fix: 버그 수정
+docs: 문서 변경
+test: 테스트 추가/수정
+ci: CI/CD 변경
+refactor: 코드 리팩터링
+chore: 기타 변경
+```
+
+## 테스트
+
+```bash
+# 단위 테스트
+make test
+
+# Docker 통합 테스트
+make docker-test
+```
+
+PR 제출 전 모든 테스트가 통과하는지 확인하세요.
+
+## PR 프로세스
+
+1. `feature/*` 또는 `fix/*` 브랜치 생성
+2. 변경 사항 구현 + 테스트 추가
+3. `make test` 통과 확인
+4. PR 생성 (설명에 관련 이슈 번호 포함)
+5. CI 통과 후 리뷰 요청
+
+## 프로젝트 구조
+
+```
+infra_auditor/     # Agent: 수집기, 규칙 엔진, CLI
+aggregator/        # Aggregator: FastAPI 서버
+frontend/          # Frontend: React + TypeScript
+tests/             # 테스트
+scripts/           # 스크립트 (Docker 테스트 등)
+```

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,0 +1,47 @@
+# Multi-stage: install agent on various OS bases
+# Usage: docker build --build-arg BASE_IMAGE=ubuntu:22.04 -f Dockerfile.agent .
+
+ARG BASE_IMAGE=ubuntu:22.04
+
+# Stage 1: Build wheel only (pure Python, no native deps)
+FROM python:3.12-slim AS builder
+
+WORKDIR /build
+COPY pyproject.toml ./
+COPY infra_auditor/ ./infra_auditor/
+RUN pip wheel --no-deps --wheel-dir /wheels .
+
+# Stage 2: Target OS
+FROM ${BASE_IMAGE}
+
+# Install Python based on distro
+RUN if [ -f /etc/centos-release ] && grep -q "release 7" /etc/centos-release 2>/dev/null; then \
+        sed -i 's|^mirrorlist=|#mirrorlist=|g' /etc/yum.repos.d/CentOS-*.repo && \
+        sed -i 's|^#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*.repo && \
+        yum install -y python3 python3-pip && yum clean all; \
+    elif command -v apt-get >/dev/null 2>&1; then \
+        apt-get update && apt-get install -y --no-install-recommends python3 python3-pip && \
+        rm -rf /var/lib/apt/lists/*; \
+    elif command -v dnf >/dev/null 2>&1; then \
+        dnf install -y python3 python3-pip && dnf clean all; \
+    fi
+
+WORKDIR /opt/infra-auditor
+
+# Install click (compatible with system Python) then the agent wheel (no-deps)
+COPY --from=builder /wheels /wheels
+RUN pip3 install --no-cache-dir --break-system-packages click 2>/dev/null || \
+    pip3 install --no-cache-dir click
+RUN pip3 install --no-cache-dir --no-deps --break-system-packages /wheels/infra_auditor*.whl 2>/dev/null || \
+    pip3 install --no-cache-dir --no-deps /wheels/infra_auditor*.whl
+
+COPY scripts/agent-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV AGGREGATOR_URL=http://aggregator:8443
+ENV SERVER_ID=""
+ENV SCAN_ROLE=auto
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.aggregator
+++ b/Dockerfile.aggregator
@@ -1,0 +1,25 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY pyproject.toml ./
+RUN pip install --no-cache-dir ".[server]"
+
+# Copy application code
+COPY aggregator/ ./aggregator/
+COPY infra_auditor/ ./infra_auditor/
+
+# Install the package
+RUN pip install --no-cache-dir -e .
+
+ENV INFRA_AUDITOR_HOST=0.0.0.0
+ENV INFRA_AUDITOR_PORT=8443
+ENV INFRA_AUDITOR_DB_PATH=/data/infra_auditor.db
+ENV INFRA_AUDITOR_DEBUG=true
+
+EXPOSE 8443
+
+VOLUME /data
+
+CMD ["python", "-m", "aggregator"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,18 @@
+# Stage 1: Build
+FROM node:22-slim AS builder
+
+WORKDIR /app
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ ./
+RUN npm run build
+
+# Stage 2: Serve
+FROM nginx:alpine
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+.PHONY: setup test test-docker lint benchmark clean docker-build docker-up docker-down
+
+# ── Development ─────────────────────────────────
+setup:
+	pip install -e ".[dev,server]"
+	cd frontend && npm ci
+
+test:
+	pytest -v --tb=short --cov=infra_auditor --cov=aggregator
+
+lint:
+	python -m py_compile infra_auditor/cli.py
+	python -m py_compile aggregator/app.py
+	cd frontend && npx tsc --noEmit
+
+benchmark:
+	@echo "Running scan benchmark..."
+	@time infra-auditor scan --role auto > /dev/null
+
+# ── Docker ──────────────────────────────────────
+docker-build:
+	docker compose build
+
+docker-up: docker-build
+	docker compose up -d
+	@echo "Waiting for services..."
+	@sleep 5
+	@echo "Stack is up → http://localhost:3000"
+
+docker-down:
+	docker compose down -v
+
+docker-test: docker-up
+	@sleep 10
+	bash scripts/test-docker.sh
+	$(MAKE) docker-down
+
+# ── Cleanup ─────────────────────────────────────
+clean:
+	docker compose down -v --rmi local 2>/dev/null || true
+	rm -rf dist/ build/ *.egg-info .pytest_cache .coverage htmlcov/
+	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -1,39 +1,151 @@
 # infra-auditor
 
-온프레미스 클라우드 인프라 OS 튜닝 점검 에이전트
+OS 튜닝 점검 에이전트 — 서버 역할별 OS 설정을 자동으로 점검하고 최적화 권장사항을 제공합니다.
 
-## Overview
-
-대규모 온프레미스 클라우드(AWS-like) 환경에서 서버 역할별 OS 설정을 자동으로 점검하고,
-하드웨어 스펙에 맞는 최적 설정을 제안하는 시스템.
-
-## Infrastructure Context
-
-- **Hardware**: Intel Xeon 4th/5th Gen (2-socket), Mellanox ConnectX-5/6 (4 NICs bonded), 1-2TB RAM
-- **OS**: CentOS 7, Ubuntu 22.04/24.04, Rocky Linux 9
-- **Regions**: 4 global regions
-- **Server Roles**:
-  - `control` — Platform management
-  - `compute` — VM hypervisor (KVM/QEMU)
-  - `network` — ELB/Load Balancer
-  - `storage-ceph` — Ceph distributed storage
-  - `storage-s3` — S3-compatible object storage
-
-## Architecture
+## 아키텍처
 
 ```
-[Agent] → per-host audit → JSON report
-   ↓
-[Aggregator] → regional dashboard → compliance overview
+┌─────────────┐     ┌─────────────────┐     ┌──────────────┐
+│   Agent      │────▶│   Aggregator    │◀────│   Frontend   │
+│  (각 서버)   │     │  (FastAPI)      │     │  (React)     │
+└─────────────┘     └─────────────────┘     └──────────────┘
 ```
 
-## Tech Stack
+- **Agent**: 시스템 정보 수집, 규칙 평가, JSON 리포트 생성
+- **Aggregator**: 리포트 수신/저장, REST API, 대시보드 데이터 제공
+- **Frontend**: React + TypeScript + Tailwind CSS 웹 대시보드
 
-- Agent: Python 3.8+ (CentOS 7 compat)
-- Dashboard: FastAPI + Modern Web UI
-- Docker: Testing & verification
-- CI/CD: GitHub Actions
+## 지원 환경
 
-## License
+| OS | 버전 | 상태 |
+|---|---|---|
+| Ubuntu | 22.04, 24.04 | ✅ |
+| CentOS | 7 | ✅ |
+| Rocky Linux | 9 | ✅ |
+
+## 빠른 시작
+
+### 설치 (개발)
+
+```bash
+# Python 패키지
+pip install -e ".[dev,server]"
+
+# Frontend
+cd frontend && npm ci
+```
+
+### Agent 실행
+
+```bash
+# 전체 스캔 (역할 자동 감지)
+infra-auditor scan
+
+# 역할 지정 + 파일 저장
+infra-auditor scan --role compute -o report.json
+
+# 요약 출력
+infra-auditor scan --format summary
+```
+
+### Aggregator 실행
+
+```bash
+# 서버 시작 (기본 포트 8443)
+infra-auditor-server
+
+# 환경변수로 설정
+INFRA_AUDITOR_PORT=9000 infra-auditor-server
+```
+
+### Frontend 실행 (개발)
+
+```bash
+cd frontend
+npm run dev
+# → http://localhost:5173
+```
+
+## Docker
+
+### 전체 스택 실행
+
+```bash
+# 빌드 & 실행
+docker compose up -d
+
+# 확인
+# - Frontend: http://localhost:3000
+# - API:      http://localhost:8443/api/v1/health
+# - Docs:     http://localhost:8443/docs
+
+# 중지
+docker compose down -v
+```
+
+### 통합 테스트
+
+```bash
+# Docker 환경에서 전체 통합 테스트 실행
+make docker-test
+```
+
+이 명령은:
+1. 모든 컨테이너 빌드 (aggregator, frontend, 4개 OS agent)
+2. 각 OS에서 Agent 실행 → 리포트 생성 → Aggregator 전송
+3. API 응답 검증 (health, dashboard, compliance, reports)
+4. Frontend 접근성 확인
+5. 완료 후 정리
+
+### 개별 이미지 빌드
+
+```bash
+# Aggregator
+docker build -f Dockerfile.aggregator -t infra-auditor-aggregator .
+
+# Frontend
+docker build -f Dockerfile.frontend -t infra-auditor-frontend .
+
+# Agent (OS별)
+docker build -f Dockerfile.agent --build-arg BASE_IMAGE=ubuntu:22.04 -t agent-ubuntu22 .
+docker build -f Dockerfile.agent --build-arg BASE_IMAGE=rockylinux:9 -t agent-rocky9 .
+```
+
+## API
+
+| Endpoint | Method | 설명 |
+|---|---|---|
+| `/api/v1/health` | GET | 서비스 상태 |
+| `/api/v1/reports` | POST | 리포트 제출 |
+| `/api/v1/reports` | GET | 리포트 목록 |
+| `/api/v1/reports/{server_id}` | GET | 서버별 리포트 |
+| `/api/v1/dashboard` | GET | 대시보드 요약 |
+| `/api/v1/compliance` | GET | 컴플라이언스 현황 |
+
+## 개발
+
+```bash
+# 테스트
+make test
+
+# 린트
+make lint
+
+# 벤치마크
+make benchmark
+
+# 전체 정리
+make clean
+```
+
+## CI/CD
+
+GitHub Actions로 자동화:
+- **Python 테스트**: pytest + coverage (Python 3.10, 3.12)
+- **Frontend 빌드**: TypeScript 컴파일 + Vite 빌드
+- **Docker 빌드**: 이미지 빌드 검증
+- **릴리즈**: `v*` 태그 push 시 GitHub Release 자동 생성
+
+## 라이선스
 
 MIT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,103 @@
+services:
+  aggregator:
+    build:
+      context: .
+      dockerfile: Dockerfile.aggregator
+    ports:
+      - "8443:8443"
+    volumes:
+      - aggregator-data:/data
+    environment:
+      - INFRA_AUDITOR_DEBUG=true
+      - INFRA_AUDITOR_DB_PATH=/data/infra_auditor.db
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8443/api/v1/health')"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+    networks:
+      - infra-net
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    ports:
+      - "3000:80"
+    depends_on:
+      aggregator:
+        condition: service_healthy
+    networks:
+      - infra-net
+
+  agent-ubuntu22:
+    build:
+      context: .
+      dockerfile: Dockerfile.agent
+      args:
+        BASE_IMAGE: ubuntu:22.04
+    environment:
+      - SERVER_ID=test-ubuntu22
+      - SCAN_ROLE=auto
+      - AGGREGATOR_URL=http://aggregator:8443
+    depends_on:
+      aggregator:
+        condition: service_healthy
+    networks:
+      - infra-net
+
+  agent-ubuntu24:
+    build:
+      context: .
+      dockerfile: Dockerfile.agent
+      args:
+        BASE_IMAGE: ubuntu:24.04
+    environment:
+      - SERVER_ID=test-ubuntu24
+      - SCAN_ROLE=auto
+      - AGGREGATOR_URL=http://aggregator:8443
+    depends_on:
+      aggregator:
+        condition: service_healthy
+    networks:
+      - infra-net
+
+  agent-centos7:
+    build:
+      context: .
+      dockerfile: Dockerfile.agent
+      args:
+        BASE_IMAGE: centos:7
+    environment:
+      - SERVER_ID=test-centos7
+      - SCAN_ROLE=auto
+      - AGGREGATOR_URL=http://aggregator:8443
+    depends_on:
+      aggregator:
+        condition: service_healthy
+    networks:
+      - infra-net
+
+  agent-rocky9:
+    build:
+      context: .
+      dockerfile: Dockerfile.agent
+      args:
+        BASE_IMAGE: rockylinux:9
+    environment:
+      - SERVER_ID=test-rocky9
+      - SCAN_ROLE=auto
+      - AGGREGATOR_URL=http://aggregator:8443
+    depends_on:
+      aggregator:
+        condition: service_healthy
+    networks:
+      - infra-net
+
+volumes:
+  aggregator-data:
+
+networks:
+  infra-net:
+    driver: bridge

--- a/infra_auditor/collectors/base.py
+++ b/infra_auditor/collectors/base.py
@@ -38,8 +38,9 @@ class BaseCollector:
         try:
             result = subprocess.run(
                 cmd,
-                capture_output=True,
-                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                universal_newlines=True,
                 timeout=timeout,
             )
             return result.stdout.strip()

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,26 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # API proxy to aggregator
+    location /api/ {
+        proxy_pass http://aggregator:8443;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "OS tuning audit agent for cloud infrastructure"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.8"
+requires-python = ">=3.6"
 dependencies = [
     "click>=7.0",
 ]

--- a/scripts/agent-entrypoint.sh
+++ b/scripts/agent-entrypoint.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -e
+
+# Defaults
+AGGREGATOR_URL="${AGGREGATOR_URL:-http://aggregator:8443}"
+SERVER_ID="${SERVER_ID:-$(hostname)}"
+SCAN_ROLE="${SCAN_ROLE:-auto}"
+REPORT_FILE="/tmp/report.json"
+
+echo "=== infra-auditor agent ==="
+echo "Server ID : ${SERVER_ID}"
+echo "Role      : ${SCAN_ROLE}"
+echo "Aggregator: ${AGGREGATOR_URL}"
+echo ""
+
+# Run scan
+echo "[1/3] Running scan..."
+infra-auditor scan --role "${SCAN_ROLE}" -o "${REPORT_FILE}"
+echo "  → Report generated: ${REPORT_FILE}"
+
+# Wait for aggregator to be ready
+echo "[2/3] Waiting for aggregator..."
+for i in $(seq 1 30); do
+    HEALTH_OK=$(python3 -c "
+import urllib.request, sys
+try:
+    resp = urllib.request.urlopen('${AGGREGATOR_URL}/api/v1/health', timeout=2)
+    print('OK')
+except Exception as e:
+    print('FAIL: ' + str(e), file=sys.stderr)
+" 2>/dev/null || true)
+    if [ "$HEALTH_OK" = "OK" ]; then
+        echo "  → Aggregator is ready"
+        break
+    fi
+    if [ "$i" -eq 30 ]; then
+        echo "  ✗ Aggregator not reachable after 30s"
+        exit 1
+    fi
+    sleep 1
+done
+
+# Submit report
+echo "[3/3] Submitting report..."
+python3 -c "
+import json, urllib.request, sys
+
+with open('${REPORT_FILE}') as f:
+    report = json.load(f)
+
+payload = json.dumps({'server_id': '${SERVER_ID}', 'report': report}).encode()
+
+req = urllib.request.Request(
+    '${AGGREGATOR_URL}/api/v1/reports',
+    data=payload,
+    headers={'Content-Type': 'application/json'},
+    method='POST'
+)
+try:
+    resp = urllib.request.urlopen(req, timeout=10)
+    print('  → Response:', resp.read().decode())
+except Exception as e:
+    print('  ✗ Submit failed:', e, file=sys.stderr)
+    sys.exit(1)
+"
+
+echo ""
+echo "=== Agent completed ==="

--- a/scripts/test-docker.sh
+++ b/scripts/test-docker.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+AGGREGATOR_URL="http://localhost:8443"
+PASS=0
+FAIL=0
+
+log_pass() { echo -e "${GREEN}✓ $1${NC}"; PASS=$((PASS+1)); }
+log_fail() { echo -e "${RED}✗ $1${NC}"; FAIL=$((FAIL+1)); }
+log_info() { echo -e "${YELLOW}→ $1${NC}"; }
+
+echo "============================================"
+echo "  infra-auditor Docker Integration Tests"
+echo "============================================"
+echo ""
+
+# 1. Check containers
+log_info "Checking container status..."
+if docker compose ps --format json | python3 -c "import sys,json; [json.loads(l) for l in sys.stdin]" 2>/dev/null; then
+    log_pass "Docker Compose containers are running"
+else
+    log_fail "Docker Compose containers check failed"
+fi
+
+# 2. Health check
+log_info "Testing health endpoint..."
+HEALTH=$(curl -sf "${AGGREGATOR_URL}/api/v1/health" 2>/dev/null || echo "FAIL")
+if echo "${HEALTH}" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['data']['service']=='healthy'" 2>/dev/null; then
+    log_pass "Health endpoint returns healthy"
+else
+    log_fail "Health endpoint check failed: ${HEALTH}"
+fi
+
+# 3. Wait for agents to complete
+log_info "Waiting for agents to submit reports (up to 60s)..."
+for i in $(seq 1 60); do
+    REPORT_COUNT=$(curl -sf "${AGGREGATOR_URL}/api/v1/health" 2>/dev/null | \
+        python3 -c "import sys,json; print(json.load(sys.stdin)['data'].get('total_reports',0))" 2>/dev/null || echo "0")
+    if [ "${REPORT_COUNT}" -ge 4 ] 2>/dev/null; then
+        log_pass "All 4 agent reports received (count: ${REPORT_COUNT})"
+        break
+    fi
+    if [ "$i" -eq 60 ]; then
+        log_fail "Only ${REPORT_COUNT}/4 reports received after 60s"
+    fi
+    sleep 1
+done
+
+# 4. Dashboard API
+log_info "Testing dashboard API..."
+DASHBOARD=$(curl -sf "${AGGREGATOR_URL}/api/v1/dashboard" 2>/dev/null || echo "FAIL")
+if echo "${DASHBOARD}" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['status']=='success'" 2>/dev/null; then
+    log_pass "Dashboard API returns success"
+else
+    log_fail "Dashboard API failed: ${DASHBOARD}"
+fi
+
+# 5. Compliance API
+log_info "Testing compliance API..."
+COMPLIANCE=$(curl -sf "${AGGREGATOR_URL}/api/v1/compliance" 2>/dev/null || echo "FAIL")
+if echo "${COMPLIANCE}" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['status']=='success'" 2>/dev/null; then
+    log_pass "Compliance API returns success"
+else
+    log_fail "Compliance API failed: ${COMPLIANCE}"
+fi
+
+# 6. Reports API
+log_info "Testing reports list API..."
+REPORTS=$(curl -sf "${AGGREGATOR_URL}/api/v1/reports" 2>/dev/null || echo "FAIL")
+if echo "${REPORTS}" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['status']=='success'" 2>/dev/null; then
+    log_pass "Reports list API returns success"
+else
+    log_fail "Reports list API failed"
+fi
+
+# 7. Individual host reports
+log_info "Testing per-host report API..."
+for host in test-ubuntu22 test-ubuntu24 test-centos7 test-rocky9; do
+    REPORT=$(curl -sf "${AGGREGATOR_URL}/api/v1/reports/${host}" 2>/dev/null || echo "FAIL")
+    if echo "${REPORT}" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['status']=='success'" 2>/dev/null; then
+        log_pass "Report for ${host} exists"
+    else
+        log_fail "Report for ${host} missing"
+    fi
+done
+
+# 8. Frontend accessibility
+log_info "Testing frontend..."
+FRONTEND=$(curl -sf -o /dev/null -w "%{http_code}" "http://localhost:3000/" 2>/dev/null || echo "000")
+if [ "${FRONTEND}" = "200" ]; then
+    log_pass "Frontend accessible on port 3000"
+else
+    log_fail "Frontend not accessible (HTTP ${FRONTEND})"
+fi
+
+# Summary
+echo ""
+echo "============================================"
+echo "  Results: ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}"
+echo "============================================"
+
+if [ "${FAIL}" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Phase 5: Docker 테스트 환경 + 최종 검증

Closes #4

### 구현 내용

**Docker Compose 스택** (6 services)
- `aggregator`: FastAPI 서버 (포트 8443)
- `frontend`: React 빌드 → Nginx 서빙 (포트 3000)
- `agent-ubuntu22`: Ubuntu 22.04 테스트 에이전트
- `agent-ubuntu24`: Ubuntu 24.04 테스트 에이전트
- `agent-centos7`: CentOS 7 테스트 에이전트 (vault 미러 대응)
- `agent-rocky9`: Rocky Linux 9 테스트 에이전트

**Dockerfiles**
- `Dockerfile.aggregator`: FastAPI 서버
- `Dockerfile.frontend`: 멀티스테이지 (Vite 빌드 → Nginx)
- `Dockerfile.agent`: 멀티스테이지, `BASE_IMAGE` ARG로 OS 선택

**테스트 자동화**
- `scripts/test-docker.sh`: 통합 테스트 (health, dashboard, compliance, reports API 검증)
- `Makefile`: setup, test, lint, benchmark, docker-build, docker-test, clean

**CI/CD**
- `.github/workflows/ci.yml`: pytest, frontend 빌드, Docker 빌드 검증, 릴리즈 자동화

**문서**
- `README.md` 전체 재작성 (설치, 사용법, Docker, API, CI/CD 가이드)
- `CONTRIBUTING.md` 추가

### 검증 결과
- ✅ 6개 Docker 이미지 빌드 성공
- ✅ `docker compose up -d` 전체 스택 실행
- ✅ 4개 OS에서 Agent 스캔 + 리포트 제출 성공 (4/4 reports)
- ✅ Aggregator API 정상 응답 (health, dashboard, compliance)
- ✅ Frontend 접속 가능 (HTTP 200)
- ✅ 기존 93개 테스트 전체 통과

### 기존 코드 변경
- `infra_auditor/collectors/base.py`: `capture_output=True` → `stdout=PIPE, stderr=PIPE` (Python 3.6 호환)
- `pyproject.toml`: `requires-python >= 3.8` → `>= 3.6` (CentOS 7 지원)