### PR TITLE
Phase 7: Drift Detection + Remediation

### DIFF
--- a/aggregator/api/drift.py
+++ b/aggregator/api/drift.py
@@ -1,0 +1,153 @@
+"""Drift detection API endpoints."""
+
+import json
+from typing import Optional
+
+from fastapi import APIRouter, Query, Request
+
+from aggregator.responses import success_response, error_response
+
+router = APIRouter(prefix="/api/v1", tags=["drift"])
+
+
+@router.post("/drift/compare")
+async def compare_reports(request: Request):
+    """Compare two reports for drift.
+
+    Body:
+        {
+            "current_report": { ... },
+            "previous_report": { ... }
+        }
+
+    Or compare by server_id (uses latest two reports):
+        {
+            "server_id": "web-01"
+        }
+    """
+    from infra_auditor.drift import DriftDetector
+
+    body = await request.json()
+
+    current = body.get("current_report")
+    previous = body.get("previous_report")
+    server_id = body.get("server_id")
+
+    if current and previous:
+        detector = DriftDetector.__new__(DriftDetector)
+        drift = detector.compare(current, previous)
+        return success_response(drift)
+
+    if server_id:
+        db = request.app.state.db
+        # Get the two most recent reports for this server
+        rows = db.conn.execute(
+            """SELECT report_data FROM reports
+               WHERE server_id = ?
+               ORDER BY received_at DESC LIMIT 2""",
+            (server_id,),
+        ).fetchall()
+
+        if len(rows) < 2:
+            return error_response(
+                404,
+                "INSUFFICIENT_DATA",
+                f"Need at least 2 reports for server '{server_id}' to compare. "
+                f"Found {len(rows)}.",
+            )
+
+        current = json.loads(rows[0]["report_data"])
+        previous = json.loads(rows[1]["report_data"])
+        detector = DriftDetector.__new__(DriftDetector)
+        drift = detector.compare(current, previous)
+        return success_response(drift)
+
+    return error_response(
+        400,
+        "VALIDATION_ERROR",
+        "Provide either (current_report + previous_report) or server_id",
+    )
+
+
+@router.get("/drift/{server_id}")
+async def get_drift(
+    request: Request,
+    server_id: str,
+):
+    """Get drift analysis for the latest two scans of a server."""
+    db = request.app.state.db
+
+    rows = db.conn.execute(
+        """SELECT report_data, received_at FROM reports
+           WHERE server_id = ?
+           ORDER BY received_at DESC LIMIT 2""",
+        (server_id,),
+    ).fetchall()
+
+    if len(rows) == 0:
+        return error_response(
+            404, "NOT_FOUND", f"No reports found for server '{server_id}'"
+        )
+
+    if len(rows) < 2:
+        return success_response({
+            "has_drift": False,
+            "message": "Only one report available, no comparison possible",
+            "latest_scan": rows[0]["received_at"],
+        })
+
+    from infra_auditor.drift import DriftDetector
+
+    current = json.loads(rows[0]["report_data"])
+    previous = json.loads(rows[1]["report_data"])
+    detector = DriftDetector.__new__(DriftDetector)
+    drift = detector.compare(current, previous)
+    return success_response(drift)
+
+
+@router.get("/drift/{server_id}/history")
+async def get_drift_history(
+    request: Request,
+    server_id: str,
+    limit: int = Query(10, ge=1, le=50),
+):
+    """Get compliance score history for a server (for trend visualization)."""
+    db = request.app.state.db
+
+    rows = db.conn.execute(
+        """SELECT id, received_at, compliance_score
+           FROM reports
+           WHERE server_id = ?
+           ORDER BY received_at DESC LIMIT ?""",
+        (server_id, limit),
+    ).fetchall()
+
+    if not rows:
+        return error_response(
+            404, "NOT_FOUND", f"No reports found for server '{server_id}'"
+        )
+
+    history = [
+        {
+            "report_id": r["id"],
+            "timestamp": r["received_at"],
+            "compliance_score": r["compliance_score"],
+        }
+        for r in rows
+    ]
+
+    # Calculate trend
+    scores = [r["compliance_score"] for r in rows]
+    if len(scores) >= 2:
+        trend = "improving" if scores[0] > scores[-1] else (
+            "declining" if scores[0] < scores[-1] else "stable"
+        )
+    else:
+        trend = "insufficient_data"
+
+    return success_response({
+        "server_id": server_id,
+        "history": history,
+        "trend": trend,
+        "latest_score": scores[0] if scores else 0,
+    })

--- a/aggregator/api/remediation.py
+++ b/aggregator/api/remediation.py
@@ -1,0 +1,126 @@
+"""Remediation API endpoints."""
+
+import json
+from typing import List, Optional
+
+from fastapi import APIRouter, Query, Request
+
+from aggregator.responses import success_response, error_response
+
+router = APIRouter(prefix="/api/v1", tags=["remediation"])
+
+
+@router.post("/remediation/generate")
+async def generate_remediation(request: Request):
+    """Generate a remediation script from a report.
+
+    Body:
+        {
+            "report": { ... full scan report ... },
+            "categories": ["cpu", "memory"],   // optional filter
+            "severities": ["critical", "warning"]  // optional filter
+        }
+
+    Or generate from the latest report for a server:
+        {
+            "server_id": "web-01",
+            "categories": ["cpu"],
+            "severities": ["critical"]
+        }
+    """
+    from infra_auditor.remediation import RemediationGenerator
+
+    body = await request.json()
+    db = request.app.state.db
+
+    report = body.get("report")
+    server_id = body.get("server_id")
+    categories = body.get("categories")
+    severities = body.get("severities")
+
+    if not report and server_id:
+        row = db.conn.execute(
+            """SELECT report_data FROM reports
+               WHERE server_id = ?
+               ORDER BY received_at DESC LIMIT 1""",
+            (server_id,),
+        ).fetchone()
+
+        if not row:
+            return error_response(
+                404,
+                "NOT_FOUND",
+                f"No reports found for server '{server_id}'",
+            )
+        report = json.loads(row["report_data"])
+
+    if not report:
+        return error_response(
+            400,
+            "VALIDATION_ERROR",
+            "Provide either 'report' object or 'server_id'",
+        )
+
+    gen = RemediationGenerator()
+    result = gen.generate(
+        report,
+        categories=categories,
+        severities=severities,
+    )
+
+    return success_response(result)
+
+
+@router.get("/remediation/{server_id}")
+async def get_remediation(
+    request: Request,
+    server_id: str,
+    severity: Optional[str] = Query(None),
+):
+    """Get remediation info for a server's latest scan.
+
+    Returns non-compliant items with fix commands.
+    """
+    db = request.app.state.db
+
+    row = db.conn.execute(
+        """SELECT report_data FROM reports
+           WHERE server_id = ?
+           ORDER BY received_at DESC LIMIT 1""",
+        (server_id,),
+    ).fetchone()
+
+    if not row:
+        return error_response(
+            404, "NOT_FOUND", f"No reports found for server '{server_id}'"
+        )
+
+    report = json.loads(row["report_data"])
+    scan_results = report.get("scan_results", {})
+
+    non_compliant = []
+    for cat, items in scan_results.items():
+        for item in items:
+            if item.get("compliance", True):
+                continue
+            if severity and item.get("severity") != severity:
+                continue
+            non_compliant.append({
+                "item": item.get("item", ""),
+                "category": item.get("category", ""),
+                "severity": item.get("severity", ""),
+                "current_value": item.get("current_value", ""),
+                "recommended_value": item.get("recommended_value", ""),
+                "description": item.get("description", ""),
+                "remediation": item.get("remediation", {}),
+            })
+
+    # Sort by severity (critical first)
+    sev_order = {"critical": 0, "warning": 1, "info": 2}
+    non_compliant.sort(key=lambda x: sev_order.get(x["severity"], 3))
+
+    return success_response({
+        "server_id": server_id,
+        "total_non_compliant": len(non_compliant),
+        "items": non_compliant,
+    })

--- a/aggregator/app.py
+++ b/aggregator/app.py
@@ -14,7 +14,7 @@ from aggregator import __version__
 from aggregator.config import Settings
 from aggregator.database import Database
 from aggregator.middleware import APIKeyMiddleware, RateLimitMiddleware
-from aggregator.api import reports, dashboard, compliance, health
+from aggregator.api import reports, dashboard, compliance, health, drift, remediation
 
 
 def create_app(settings: Optional[Settings] = None) -> FastAPI:
@@ -62,6 +62,8 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
     app.include_router(dashboard.router)
     app.include_router(compliance.router)
     app.include_router(health.router)
+    app.include_router(drift.router)
+    app.include_router(remediation.router)
 
     # ── Static frontend serving ────────────────────────────
     frontend_dir = os.getenv(

--- a/infra_auditor/cli.py
+++ b/infra_auditor/cli.py
@@ -6,6 +6,8 @@ import sys
 import click
 
 import infra_auditor
+from infra_auditor.drift import DriftDetector
+from infra_auditor.remediation import RemediationGenerator
 from infra_auditor.report import Report
 from infra_auditor.utils.role_detector import VALID_ROLES
 
@@ -49,7 +51,17 @@ def main():
     default=2,
     help="JSON 들여쓰기 (기본: 2)",
 )
-def scan(role, output, fmt, indent):
+@click.option(
+    "--save/--no-save",
+    default=True,
+    help="스캔 결과를 히스토리에 저장 (기본: 저장)",
+)
+@click.option(
+    "--show-drift/--no-drift",
+    default=True,
+    help="이전 스캔 대비 변경 사항 표시 (summary 형식에서)",
+)
+def scan(role, output, fmt, indent, save, show_drift):
     """시스템 스캔 및 규칙 평가를 실행합니다.
 
     Examples:
@@ -63,7 +75,18 @@ def scan(role, output, fmt, indent):
     report = Report(role=role if role != "auto" else None)
 
     if fmt == "json":
-        json_str = report.to_json(indent=indent)
+        data = report.generate()
+        drift_data = None
+        if save:
+            detector = DriftDetector()
+            hostname = data.get("server_info", {}).get("hostname", "unknown")
+            prev = detector.get_previous(hostname)
+            if prev and show_drift:
+                drift_data = detector.compare(data, prev)
+                data["drift"] = drift_data
+            detector.save_scan(data)
+
+        json_str = json.dumps(data, indent=indent, ensure_ascii=False)
         if output:
             with open(output, "w") as f:
                 f.write(json_str)
@@ -72,14 +95,150 @@ def scan(role, output, fmt, indent):
             click.echo(json_str)
     elif fmt == "summary":
         data = report.generate()
-        _print_summary(data)
+        drift_data = None
+        if save:
+            detector = DriftDetector()
+            hostname = data.get("server_info", {}).get("hostname", "unknown")
+            prev = detector.get_previous(hostname)
+            if prev and show_drift:
+                drift_data = detector.compare(data, prev)
+            detector.save_scan(data)
+
+        _print_summary(data, drift_data)
         if output:
             with open(output, "w") as f:
                 json.dump(data, f, indent=indent, ensure_ascii=False)
             click.echo(f"\n상세 리포트 저장: {output}")
 
 
-def _print_summary(data):
+@main.command()
+@click.option(
+    "--hostname",
+    default=None,
+    help="비교할 호스트명 (미지정 시 현재 호스트)",
+)
+@click.option(
+    "--limit",
+    default=10,
+    help="히스토리 개수 제한",
+)
+def drift(hostname, limit):
+    """이전 스캔과의 drift(변경 사항)를 확인합니다.
+
+    현재 스캔을 실행하고 마지막 저장된 결과와 비교합니다.
+
+    Examples:
+
+        infra-auditor drift
+
+        infra-auditor drift --hostname myserver
+    """
+    report = Report()
+    data = report.generate()
+
+    if hostname is None:
+        hostname = data.get("server_info", {}).get("hostname", "unknown")
+
+    detector = DriftDetector()
+    prev = detector.get_previous(hostname)
+
+    if prev is None:
+        click.echo("이전 스캔 결과가 없습니다. 먼저 scan을 실행하세요.")
+        click.echo("현재 스캔 결과를 저장합니다...")
+        detector.save_scan(data)
+        click.echo("다음 실행 시 drift를 확인할 수 있습니다.")
+        return
+
+    drift_result = detector.compare(data, prev)
+    _print_drift(drift_result)
+
+    # Save current scan
+    detector.save_scan(data)
+
+
+@main.command()
+@click.option(
+    "--role",
+    type=click.Choice(["auto"] + VALID_ROLES),
+    default="auto",
+    help="서버 역할 (auto=자동감지)",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(),
+    default=None,
+    help="스크립트 출력 파일 (미지정 시 stdout)",
+)
+@click.option(
+    "--severity",
+    type=click.Choice(["critical", "warning", "info"]),
+    multiple=True,
+    help="특정 심각도만 포함 (복수 지정 가능)",
+)
+@click.option(
+    "--category",
+    multiple=True,
+    help="특정 카테고리만 포함 (복수 지정 가능)",
+)
+def remediate(role, output, severity, category):
+    """비준수 항목에 대한 수정 스크립트를 생성합니다.
+
+    Examples:
+
+        infra-auditor remediate --role compute
+
+        infra-auditor remediate --severity critical --severity warning
+
+        infra-auditor remediate -o fix.sh
+    """
+    report = Report(role=role if role != "auto" else None)
+    data = report.generate()
+
+    gen = RemediationGenerator()
+    result = gen.generate(
+        data,
+        categories=list(category) if category else None,
+        severities=list(severity) if severity else None,
+    )
+
+    if result["total_fixes"] == 0:
+        click.echo("✅ 모든 항목이 준수 상태입니다. 수정할 항목이 없습니다.")
+        return
+
+    click.echo(f"📝 {result['total_fixes']}개 비준수 항목에 대한 수정 스크립트 생성")
+
+    if result["reboot_required"]:
+        click.echo(
+            click.style("⚠ 일부 변경사항은 리부트가 필요합니다.", fg="yellow")
+        )
+
+    click.echo("-" * 60)
+    for item in result["items"]:
+        sev_color = {
+            "critical": "red",
+            "warning": "yellow",
+            "info": "blue",
+        }.get(item["severity"], "white")
+        click.echo(
+            f"  [{click.style(item['severity'].upper(), fg=sev_color)}] "
+            f"{item['item']}: {item['current_value']} → {item['recommended_value']} "
+            f"({item['fix_type']})"
+        )
+    click.echo("-" * 60)
+
+    if output:
+        with open(output, "w") as f:
+            f.write(result["script"])
+        click.echo(f"\n스크립트 저장: {output}")
+        click.echo(f"실행 전 검토: cat {output}")
+        click.echo(f"Dry-run: bash {output} --dry-run")
+        click.echo(f"적용: sudo bash {output}")
+    else:
+        click.echo("\n" + result["script"])
+
+
+def _print_summary(data, drift_data=None):
     """Print a human-readable summary of the report."""
     server = data.get("server_info", {})
     compliance = data.get("compliance", {})
@@ -103,9 +262,17 @@ def _print_summary(data):
         color = "yellow"
     else:
         color = "red"
-    click.echo(
-        f"  전체 점수: {click.style(str(score), fg=color, bold=True)}/100"
-    )
+
+    score_str = click.style(str(score), fg=color, bold=True)
+    # Show score delta if drift available
+    if drift_data:
+        delta = drift_data.get("score_change", {}).get("delta", 0)
+        if delta > 0:
+            score_str += click.style(f" (+{delta})", fg="green")
+        elif delta < 0:
+            score_str += click.style(f" ({delta})", fg="red")
+
+    click.echo(f"  전체 점수: {score_str}/100")
 
     severity = compliance.get("severity_summary", {})
     click.echo(
@@ -135,9 +302,153 @@ def _print_summary(data):
         for rec in recs:
             click.echo(f"    • {rec['item']} (영향도: {rec['impact']})")
 
+    # Drift section
+    if drift_data and drift_data.get("summary", {}).get("has_drift"):
+        click.echo("-" * 60)
+        _print_drift_compact(drift_data)
+
     if errors:
         click.echo("-" * 60)
         click.echo(f"  수집 오류: {len(errors)}건")
+
+    click.echo("=" * 60)
+
+
+def _print_drift_compact(drift_data):
+    """Print compact drift info within summary."""
+    summary = drift_data.get("summary", {})
+    click.echo(
+        click.style("  🔄 Drift 감지:", fg="cyan", bold=True)
+    )
+    parts = []
+    if summary.get("improved", 0):
+        parts.append(click.style(f"{summary['improved']} 개선", fg="green"))
+    if summary.get("degraded", 0):
+        parts.append(click.style(f"{summary['degraded']} 악화", fg="red"))
+    if summary.get("changed", 0) - summary.get("improved", 0) - summary.get("degraded", 0) > 0:
+        neutral = summary["changed"] - summary.get("improved", 0) - summary.get("degraded", 0)
+        parts.append(click.style(f"{neutral} 변경", fg="yellow"))
+    click.echo(f"    {', '.join(parts)}")
+
+    for item in drift_data.get("items", [])[:5]:
+        dtype = item["drift_type"]
+        if dtype == "improved":
+            icon = click.style("↑", fg="green")
+        elif dtype == "degraded":
+            icon = click.style("↓", fg="red")
+        elif dtype == "added":
+            icon = click.style("+", fg="cyan")
+        elif dtype == "removed":
+            icon = click.style("-", fg="magenta")
+        else:
+            icon = click.style("~", fg="yellow")
+
+        click.echo(
+            f"    {icon} {item['item']}: "
+            f"{item.get('previous_value', '?')} → {item.get('current_value', '?')}"
+        )
+
+    remaining = len(drift_data.get("items", [])) - 5
+    if remaining > 0:
+        click.echo(f"    ... {remaining}개 더 (infra-auditor drift 로 전체 확인)")
+
+
+def _print_drift(drift_data):
+    """Print full drift report."""
+    summary = drift_data.get("summary", {})
+    score = drift_data.get("score_change", {})
+
+    click.echo("=" * 60)
+    click.echo("  infra-auditor Drift Report")
+    click.echo("=" * 60)
+
+    click.echo(
+        f"  이전 스캔: {drift_data.get('previous_timestamp', '?')}"
+    )
+    click.echo(
+        f"  현재 스캔: {drift_data.get('current_timestamp', '?')}"
+    )
+    click.echo("-" * 60)
+
+    # Score change
+    delta = score.get("delta", 0)
+    if delta > 0:
+        delta_str = click.style(f"+{delta}", fg="green", bold=True)
+    elif delta < 0:
+        delta_str = click.style(str(delta), fg="red", bold=True)
+    else:
+        delta_str = click.style("0", fg="white")
+
+    click.echo(
+        f"  점수 변화: {score.get('previous', '?')} → {score.get('current', '?')} "
+        f"({delta_str})"
+    )
+    click.echo("-" * 60)
+
+    if not summary.get("has_drift"):
+        click.echo(
+            click.style("  ✅ 변경 사항 없음", fg="green", bold=True)
+        )
+        click.echo("=" * 60)
+        return
+
+    click.echo(
+        f"  검사 항목: {summary.get('total_items_checked', 0)}개"
+    )
+    click.echo(
+        f"  변경 없음: {summary.get('unchanged', 0)}개"
+    )
+
+    if summary.get("improved", 0):
+        click.echo(
+            f"  개선:     {click.style(str(summary['improved']), fg='green')}개"
+        )
+    if summary.get("degraded", 0):
+        click.echo(
+            f"  악화:     {click.style(str(summary['degraded']), fg='red')}개"
+        )
+    changed_other = summary.get("changed", 0) - summary.get("improved", 0) - summary.get("degraded", 0)
+    if changed_other > 0:
+        click.echo(
+            f"  변경:     {click.style(str(changed_other), fg='yellow')}개"
+        )
+    if summary.get("added", 0):
+        click.echo(f"  추가:     {summary['added']}개")
+    if summary.get("removed", 0):
+        click.echo(f"  제거:     {summary['removed']}개")
+
+    click.echo("-" * 60)
+    click.echo("  상세:")
+
+    for item in drift_data.get("items", []):
+        dtype = item["drift_type"]
+        if dtype == "improved":
+            icon = click.style("  ✅", fg="green")
+            direction = click.style("개선", fg="green")
+        elif dtype == "degraded":
+            icon = click.style("  ❌", fg="red")
+            direction = click.style("악화", fg="red")
+        elif dtype == "added":
+            icon = click.style("  ➕", fg="cyan")
+            direction = "추가"
+        elif dtype == "removed":
+            icon = click.style("  ➖", fg="magenta")
+            direction = "제거"
+        else:
+            icon = click.style("  🔄", fg="yellow")
+            direction = click.style("변경", fg="yellow")
+
+        sev = item.get("severity", "info")
+        sev_color = {"critical": "red", "warning": "yellow"}.get(sev, "white")
+
+        click.echo(
+            f"{icon} [{click.style(sev.upper(), fg=sev_color)}] "
+            f"{item['item']} ({direction})"
+        )
+        if item.get("previous_value") is not None:
+            click.echo(f"     이전: {item['previous_value']}")
+        if item.get("current_value") is not None:
+            click.echo(f"     현재: {item['current_value']}")
 
     click.echo("=" * 60)
 

--- a/infra_auditor/drift.py
+++ b/infra_auditor/drift.py
@@ -1,0 +1,209 @@
+"""Drift detection: compare scan results across runs."""
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+DEFAULT_HISTORY_DIR = os.path.expanduser("~/.infra-auditor/history")
+
+
+class DriftDetector:
+    """Compare current scan results against a previous baseline."""
+
+    def __init__(self, history_dir: str = DEFAULT_HISTORY_DIR):
+        self.history_dir = Path(history_dir)
+        self.history_dir.mkdir(parents=True, exist_ok=True)
+
+    def _host_dir(self, hostname: str) -> Path:
+        """Get per-host history directory."""
+        safe = hostname.replace("/", "_").replace("..", "_")
+        d = self.history_dir / safe
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def save_scan(self, report: Dict[str, Any]) -> str:
+        """Save a scan report to history. Returns the saved file path."""
+        hostname = report.get("server_info", {}).get("hostname", "unknown")
+        scan_id = report.get("metadata", {}).get("scan_id", "unknown")
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+        host_dir = self._host_dir(hostname)
+        filename = f"{ts}_{scan_id[:8]}.json"
+        path = host_dir / filename
+
+        with open(path, "w") as f:
+            json.dump(report, f, ensure_ascii=False, indent=2)
+
+        # Maintain a symlink to latest
+        latest = host_dir / "latest.json"
+        if latest.is_symlink() or latest.exists():
+            latest.unlink()
+        latest.symlink_to(path.name)
+
+        return str(path)
+
+    def get_previous(self, hostname: str) -> Optional[Dict[str, Any]]:
+        """Load the most recent saved scan for a host."""
+        host_dir = self._host_dir(hostname)
+        latest = host_dir / "latest.json"
+
+        if not latest.exists():
+            return None
+
+        with open(latest) as f:
+            return json.load(f)
+
+    def get_history(
+        self, hostname: str, limit: int = 10
+    ) -> List[Dict[str, Any]]:
+        """List saved scans for a host (newest first)."""
+        host_dir = self._host_dir(hostname)
+        files = sorted(host_dir.glob("2*.json"), reverse=True)[:limit]
+        results = []
+        for fp in files:
+            try:
+                with open(fp) as f:
+                    data = json.load(f)
+                results.append({
+                    "file": str(fp),
+                    "scan_id": data.get("metadata", {}).get("scan_id", ""),
+                    "timestamp": data.get("metadata", {}).get("timestamp", ""),
+                    "compliance_score": data.get("compliance", {}).get(
+                        "overall_score", 0
+                    ),
+                })
+            except (json.JSONDecodeError, OSError):
+                continue
+        return results
+
+    def compare(
+        self,
+        current: Dict[str, Any],
+        previous: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Compare two scan reports and return drift analysis.
+
+        Returns a dict with:
+        - summary: overall drift stats
+        - items: list of individual drift entries
+        - score_change: compliance score delta
+        """
+        cur_results = self._flatten_scan_results(current)
+        prev_results = self._flatten_scan_results(previous)
+
+        cur_keys = set(cur_results.keys())
+        prev_keys = set(prev_results.keys())
+
+        added = cur_keys - prev_keys
+        removed = prev_keys - cur_keys
+        common = cur_keys & prev_keys
+
+        items: List[Dict[str, Any]] = []
+
+        for key in sorted(added):
+            entry = cur_results[key]
+            items.append({
+                "item": key,
+                "drift_type": "added",
+                "category": entry.get("category", ""),
+                "current_value": entry.get("current_value", ""),
+                "previous_value": None,
+                "current_compliance": entry.get("compliance", False),
+                "previous_compliance": None,
+                "severity": entry.get("severity", "info"),
+            })
+
+        for key in sorted(removed):
+            entry = prev_results[key]
+            items.append({
+                "item": key,
+                "drift_type": "removed",
+                "category": entry.get("category", ""),
+                "current_value": None,
+                "previous_value": entry.get("current_value", ""),
+                "current_compliance": None,
+                "previous_compliance": entry.get("compliance", False),
+                "severity": entry.get("severity", "info"),
+            })
+
+        changed_items = []
+        for key in sorted(common):
+            cur = cur_results[key]
+            prev = prev_results[key]
+            cur_val = cur.get("current_value", "")
+            prev_val = prev.get("current_value", "")
+
+            if cur_val != prev_val:
+                cur_comp = cur.get("compliance", False)
+                prev_comp = prev.get("compliance", False)
+
+                if prev_comp and not cur_comp:
+                    direction = "degraded"
+                elif not prev_comp and cur_comp:
+                    direction = "improved"
+                else:
+                    direction = "changed"
+
+                entry = {
+                    "item": key,
+                    "drift_type": direction,
+                    "category": cur.get("category", ""),
+                    "current_value": cur_val,
+                    "previous_value": prev_val,
+                    "current_compliance": cur_comp,
+                    "previous_compliance": prev_comp,
+                    "severity": cur.get("severity", "info"),
+                }
+                items.append(entry)
+                changed_items.append(entry)
+
+        cur_score = current.get("compliance", {}).get("overall_score", 0)
+        prev_score = previous.get("compliance", {}).get("overall_score", 0)
+
+        summary = {
+            "total_items_checked": len(cur_keys | prev_keys),
+            "added": len(added),
+            "removed": len(removed),
+            "changed": len(changed_items),
+            "improved": sum(
+                1 for i in changed_items if i["drift_type"] == "improved"
+            ),
+            "degraded": sum(
+                1 for i in changed_items if i["drift_type"] == "degraded"
+            ),
+            "unchanged": len(common) - len(changed_items),
+            "has_drift": bool(added or removed or changed_items),
+        }
+
+        return {
+            "summary": summary,
+            "score_change": {
+                "current": cur_score,
+                "previous": prev_score,
+                "delta": cur_score - prev_score,
+            },
+            "items": items,
+            "current_timestamp": current.get("metadata", {}).get(
+                "timestamp", ""
+            ),
+            "previous_timestamp": previous.get("metadata", {}).get(
+                "timestamp", ""
+            ),
+        }
+
+    @staticmethod
+    def _flatten_scan_results(
+        report: Dict[str, Any],
+    ) -> Dict[str, Dict[str, Any]]:
+        """Flatten scan_results categories into a dict keyed by item name."""
+        flat: Dict[str, Dict[str, Any]] = {}
+        scan_results = report.get("scan_results", {})
+        for category, items in scan_results.items():
+            if isinstance(items, list):
+                for item in items:
+                    key = item.get("item", "")
+                    if key:
+                        flat[key] = item
+        return flat

--- a/infra_auditor/remediation.py
+++ b/infra_auditor/remediation.py
@@ -1,0 +1,306 @@
+"""Remediation script generation for non-compliant items."""
+
+import textwrap
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+
+class RemediationGenerator:
+    """Generate shell scripts to fix non-compliant audit findings."""
+
+    SCRIPT_HEADER = textwrap.dedent("""\
+        #!/usr/bin/env bash
+        # ============================================================
+        # infra-auditor Remediation Script
+        # Generated: {timestamp}
+        # Host: {hostname}
+        # Role: {role}
+        # ============================================================
+        # WARNING: Review this script before execution!
+        # Run with --dry-run first: bash {script_name} --dry-run
+        # ============================================================
+
+        set -euo pipefail
+
+        DRY_RUN=false
+        if [[ "${{1:-}}" == "--dry-run" ]]; then
+            DRY_RUN=true
+            echo "[DRY-RUN] No changes will be made."
+        fi
+
+        BACKUP_DIR="/var/backups/infra-auditor/$(date +%Y%m%d_%H%M%S)"
+        CHANGES_LOG="$BACKUP_DIR/changes.log"
+
+        log() {{
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$CHANGES_LOG"
+        }}
+
+        backup_file() {{
+            local src="$1"
+            if [[ -f "$src" ]]; then
+                local dest="$BACKUP_DIR/$(echo "$src" | tr '/' '_')"
+                cp -a "$src" "$dest"
+                log "BACKUP: $src -> $dest"
+            fi
+        }}
+
+        apply_sysctl() {{
+            local key="$1"
+            local value="$2"
+            local current
+            current=$(sysctl -n "$key" 2>/dev/null || echo "UNKNOWN")
+            if [[ "$current" == "$value" ]]; then
+                log "SKIP: $key already set to $value"
+                return
+            fi
+            if $DRY_RUN; then
+                log "DRY-RUN: sysctl -w $key=$value (current: $current)"
+            else
+                sysctl -w "$key=$value"
+                log "APPLIED: $key = $value (was: $current)"
+            fi
+        }}
+
+        persist_sysctl() {{
+            local key="$1"
+            local value="$2"
+            local conf_file="/etc/sysctl.d/99-infra-auditor.conf"
+            if $DRY_RUN; then
+                log "DRY-RUN: Would persist $key = $value in $conf_file"
+                return
+            fi
+            backup_file "$conf_file"
+            # Remove existing entry for this key, then append
+            if [[ -f "$conf_file" ]]; then
+                sed -i "/^$key\\s*=/d" "$conf_file"
+            fi
+            echo "$key = $value" >> "$conf_file"
+            log "PERSISTED: $key = $value in $conf_file"
+        }}
+
+        # ── Setup ─────────────────────────────────────────
+        if ! $DRY_RUN; then
+            mkdir -p "$BACKUP_DIR"
+            log "Remediation started"
+            backup_file "/etc/sysctl.conf"
+            [[ -d /etc/sysctl.d ]] && backup_file "/etc/sysctl.d/99-infra-auditor.conf"
+        else
+            CHANGES_LOG="/dev/null"
+            log "Dry-run remediation started"
+        fi
+
+        echo ""
+    """)
+
+    SCRIPT_FOOTER = textwrap.dedent("""\
+
+        # ── Verification ──────────────────────────────────
+        echo ""
+        echo "============================================================"
+        if $DRY_RUN; then
+            echo "DRY-RUN complete. No changes were made."
+            echo "Run without --dry-run to apply changes."
+        else
+            log "Remediation complete. Backup: $BACKUP_DIR"
+            echo "Backup directory: $BACKUP_DIR"
+            echo "Changes log: $CHANGES_LOG"
+
+            # Reload sysctl
+            if [[ -f /etc/sysctl.d/99-infra-auditor.conf ]]; then
+                sysctl -p /etc/sysctl.d/99-infra-auditor.conf 2>/dev/null || true
+                log "Reloaded sysctl configuration"
+            fi
+        fi
+        echo "============================================================"
+    """)
+
+    def __init__(self):
+        self.sysctl_items: List[Dict[str, Any]] = []
+        self.other_items: List[Dict[str, Any]] = []
+        self.reboot_required = False
+
+    def generate(
+        self,
+        report: Dict[str, Any],
+        categories: Optional[List[str]] = None,
+        severities: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Generate remediation from a scan report.
+
+        Args:
+            report: Full scan report dict
+            categories: Filter to specific categories (None = all)
+            severities: Filter to specific severities (None = all)
+
+        Returns:
+            Dict with script content, items list, and metadata
+        """
+        self.sysctl_items = []
+        self.other_items = []
+        self.reboot_required = False
+
+        scan_results = report.get("scan_results", {})
+        server_info = report.get("server_info", {})
+        hostname = server_info.get("hostname", "unknown")
+        role = server_info.get("role", "unknown")
+        if isinstance(role, dict):
+            role = role.get("detected", "unknown")
+
+        non_compliant = []
+        for cat, items in scan_results.items():
+            if categories and cat not in categories:
+                continue
+            for item in items:
+                if item.get("compliance", True):
+                    continue
+                if severities and item.get("severity") not in severities:
+                    continue
+                non_compliant.append(item)
+
+        if not non_compliant:
+            return {
+                "script": "",
+                "items": [],
+                "total_fixes": 0,
+                "reboot_required": False,
+                "hostname": hostname,
+                "role": role,
+            }
+
+        self._classify_items(non_compliant)
+        script = self._build_script(hostname, role)
+
+        return {
+            "script": script,
+            "items": [
+                {
+                    "item": it["item"],
+                    "category": it.get("category", ""),
+                    "severity": it.get("severity", ""),
+                    "current_value": it.get("current_value", ""),
+                    "recommended_value": it.get("recommended_value", ""),
+                    "fix_type": self._get_fix_type(it),
+                }
+                for it in non_compliant
+            ],
+            "total_fixes": len(non_compliant),
+            "reboot_required": self.reboot_required,
+            "hostname": hostname,
+            "role": role,
+        }
+
+    def _classify_items(self, items: List[Dict[str, Any]]) -> None:
+        """Classify items by remediation type."""
+        for item in items:
+            remediation = item.get("remediation", {})
+            if remediation.get("requires_reboot", False):
+                self.reboot_required = True
+
+            cmd = remediation.get("command", "")
+            # Detect sysctl items
+            if "sysctl" in cmd or item.get("item", "").startswith(
+                ("vm.", "net.", "kernel.", "fs.")
+            ):
+                self.sysctl_items.append(item)
+            elif cmd:
+                self.other_items.append(item)
+            else:
+                # Items without a command go to other (manual)
+                self.other_items.append(item)
+
+    def _get_fix_type(self, item: Dict[str, Any]) -> str:
+        """Determine the fix type for an item."""
+        remediation = item.get("remediation", {})
+        cmd = remediation.get("command", "")
+        if "sysctl" in cmd or item.get("item", "").startswith(
+            ("vm.", "net.", "kernel.", "fs.")
+        ):
+            return "sysctl"
+        if cmd:
+            return "command"
+        if remediation.get("requires_reboot"):
+            return "reboot_required"
+        return "manual"
+
+    def _build_script(self, hostname: str, role: str) -> str:
+        """Build the full remediation shell script."""
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+        parts = [
+            self.SCRIPT_HEADER.format(
+                timestamp=ts,
+                hostname=hostname,
+                role=role,
+                script_name="remediate.sh",
+            )
+        ]
+
+        if self.sysctl_items:
+            parts.append("# ── Sysctl Fixes ──────────────────────────────")
+            for item in self.sysctl_items:
+                name = item["item"]
+                rec = item.get("recommended_value", "")
+                desc = item.get("description", "")
+                cur = item.get("current_value", "")
+                sev = item.get("severity", "info")
+
+                # Convert item name to sysctl key format
+                sysctl_key = name.replace("-", ".")
+
+                parts.append(f'echo "── [{sev.upper()}] {name}: {desc}"')
+                parts.append(f'echo "   Current: {cur} → Recommended: {rec}"')
+                parts.append(f'apply_sysctl "{sysctl_key}" "{rec}"')
+                parts.append(f'persist_sysctl "{sysctl_key}" "{rec}"')
+                parts.append("")
+
+        if self.other_items:
+            parts.append(
+                "# ── Other Fixes ───────────────────────────────"
+            )
+            for item in self.other_items:
+                name = item["item"]
+                remediation = item.get("remediation", {})
+                cmd = remediation.get("command", "")
+                desc = item.get("description", "")
+                sev = item.get("severity", "info")
+
+                parts.append(f'echo "── [{sev.upper()}] {name}: {desc}"')
+                if cmd:
+                    parts.append(f"if $DRY_RUN; then")
+                    parts.append(f'    log "DRY-RUN: {cmd}"')
+                    parts.append(f"else")
+                    parts.append(f"    {cmd}")
+                    parts.append(
+                        f'    log "APPLIED: {name}"'
+                    )
+                    parts.append(f"fi")
+                else:
+                    persistent = remediation.get("persistent", "")
+                    if persistent:
+                        parts.append(
+                            f'log "MANUAL: {name} — {persistent}"'
+                        )
+                    else:
+                        parts.append(
+                            f'log "MANUAL: {name} — no auto-fix available"'
+                        )
+                parts.append("")
+
+        if self.reboot_required:
+            parts.append(
+                'echo ""'
+            )
+            parts.append(
+                'echo "⚠ WARNING: Some changes require a reboot to take effect."'
+            )
+
+        parts.append(self.SCRIPT_FOOTER)
+        return "\n".join(parts)
+
+    @staticmethod
+    def generate_single_fix(item: Dict[str, Any]) -> Optional[str]:
+        """Generate a single-item fix command (for API use)."""
+        remediation = item.get("remediation", {})
+        cmd = remediation.get("command", "")
+        if cmd:
+            return cmd
+        return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,33 +68,48 @@ class TestCLI:
         assert "--output" in result.output
         assert "--format" in result.output
 
+    @patch("infra_auditor.cli.DriftDetector")
     @patch("infra_auditor.cli.Report")
-    def test_scan_json_stdout(self, mock_report_cls, runner, mock_report_data):
+    def test_scan_json_stdout(self, mock_report_cls, mock_drift_cls, runner, mock_report_data):
         mock_report = MagicMock()
-        mock_report.to_json.return_value = json.dumps(mock_report_data)
+        mock_report.generate.return_value = mock_report_data
         mock_report_cls.return_value = mock_report
+
+        mock_detector = MagicMock()
+        mock_detector.get_previous.return_value = None
+        mock_drift_cls.return_value = mock_detector
 
         result = runner.invoke(main, ["scan", "--role", "compute"])
         assert result.exit_code == 0
         output = json.loads(result.output)
         assert output["server_info"]["role"] == "compute"
 
+    @patch("infra_auditor.cli.DriftDetector")
     @patch("infra_auditor.cli.Report")
-    def test_scan_json_file(self, mock_report_cls, runner, mock_report_data, tmp_path):
+    def test_scan_json_file(self, mock_report_cls, mock_drift_cls, runner, mock_report_data, tmp_path):
         mock_report = MagicMock()
-        mock_report.to_json.return_value = json.dumps(mock_report_data)
+        mock_report.generate.return_value = mock_report_data
         mock_report_cls.return_value = mock_report
+
+        mock_detector = MagicMock()
+        mock_detector.get_previous.return_value = None
+        mock_drift_cls.return_value = mock_detector
 
         outpath = str(tmp_path / "out.json")
         result = runner.invoke(main, ["scan", "--role", "control", "-o", outpath])
         assert result.exit_code == 0
         assert "리포트 저장" in result.output
 
+    @patch("infra_auditor.cli.DriftDetector")
     @patch("infra_auditor.cli.Report")
-    def test_scan_summary(self, mock_report_cls, runner, mock_report_data):
+    def test_scan_summary(self, mock_report_cls, mock_drift_cls, runner, mock_report_data):
         mock_report = MagicMock()
         mock_report.generate.return_value = mock_report_data
         mock_report_cls.return_value = mock_report
+
+        mock_detector = MagicMock()
+        mock_detector.get_previous.return_value = None
+        mock_drift_cls.return_value = mock_detector
 
         result = runner.invoke(main, ["scan", "--role", "compute", "--format", "summary"])
         assert result.exit_code == 0
@@ -104,3 +119,103 @@ class TestCLI:
     def test_scan_invalid_role(self, runner):
         result = runner.invoke(main, ["scan", "--role", "invalid"])
         assert result.exit_code != 0
+
+    @patch("infra_auditor.cli.DriftDetector")
+    @patch("infra_auditor.cli.Report")
+    def test_scan_no_save(self, mock_report_cls, mock_drift_cls, runner, mock_report_data):
+        mock_report = MagicMock()
+        mock_report.generate.return_value = mock_report_data
+        mock_report_cls.return_value = mock_report
+
+        result = runner.invoke(main, ["scan", "--role", "compute", "--no-save"])
+        assert result.exit_code == 0
+        # DriftDetector should not be instantiated when --no-save
+        mock_drift_cls.assert_not_called()
+
+    @patch("infra_auditor.cli.DriftDetector")
+    @patch("infra_auditor.cli.Report")
+    def test_scan_with_drift(self, mock_report_cls, mock_drift_cls, runner, mock_report_data):
+        mock_report = MagicMock()
+        mock_report.generate.return_value = mock_report_data
+        mock_report_cls.return_value = mock_report
+
+        # Simulate a previous scan exists
+        prev_data = dict(mock_report_data)
+        mock_detector = MagicMock()
+        mock_detector.get_previous.return_value = prev_data
+        mock_detector.compare.return_value = {
+            "summary": {"has_drift": False, "changed": 0},
+            "score_change": {"current": 75, "previous": 75, "delta": 0},
+            "items": [],
+        }
+        mock_drift_cls.return_value = mock_detector
+
+        result = runner.invoke(
+            main, ["scan", "--role", "compute", "--format", "summary"]
+        )
+        assert result.exit_code == 0
+        mock_detector.compare.assert_called_once()
+
+    def test_drift_help(self, runner):
+        result = runner.invoke(main, ["drift", "--help"])
+        assert result.exit_code == 0
+        assert "drift" in result.output.lower()
+
+    def test_remediate_help(self, runner):
+        result = runner.invoke(main, ["remediate", "--help"])
+        assert result.exit_code == 0
+        assert "--severity" in result.output
+
+    @patch("infra_auditor.cli.RemediationGenerator")
+    @patch("infra_auditor.cli.Report")
+    def test_remediate_all_compliant(self, mock_report_cls, mock_gen_cls, runner, mock_report_data):
+        mock_report = MagicMock()
+        mock_report.generate.return_value = mock_report_data
+        mock_report_cls.return_value = mock_report
+
+        mock_gen = MagicMock()
+        mock_gen.generate.return_value = {
+            "script": "",
+            "items": [],
+            "total_fixes": 0,
+            "reboot_required": False,
+            "hostname": "test-host",
+            "role": "compute",
+        }
+        mock_gen_cls.return_value = mock_gen
+
+        result = runner.invoke(main, ["remediate", "--role", "compute"])
+        assert result.exit_code == 0
+        assert "모든 항목이 준수" in result.output
+
+    @patch("infra_auditor.cli.RemediationGenerator")
+    @patch("infra_auditor.cli.Report")
+    def test_remediate_with_fixes(self, mock_report_cls, mock_gen_cls, runner, mock_report_data):
+        mock_report = MagicMock()
+        mock_report.generate.return_value = mock_report_data
+        mock_report_cls.return_value = mock_report
+
+        mock_gen = MagicMock()
+        mock_gen.generate.return_value = {
+            "script": "#!/bin/bash\necho test",
+            "items": [
+                {
+                    "item": "vm.swappiness",
+                    "category": "memory",
+                    "severity": "critical",
+                    "current_value": "60",
+                    "recommended_value": "1",
+                    "fix_type": "sysctl",
+                },
+            ],
+            "total_fixes": 1,
+            "reboot_required": False,
+            "hostname": "test-host",
+            "role": "compute",
+        }
+        mock_gen_cls.return_value = mock_gen
+
+        result = runner.invoke(main, ["remediate", "--role", "compute"])
+        assert result.exit_code == 0
+        assert "1개 비준수 항목" in result.output
+        assert "vm.swappiness" in result.output

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -1,0 +1,257 @@
+"""Tests for DriftDetector."""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from infra_auditor.drift import DriftDetector
+
+
+def _make_report(
+    hostname="test-host",
+    scan_id="scan-001",
+    timestamp="2024-03-07T12:00:00Z",
+    overall_score=75,
+    items=None,
+):
+    """Build a minimal report for drift testing."""
+    if items is None:
+        items = {
+            "cpu": [
+                {
+                    "item": "scaling_governor",
+                    "category": "cpu",
+                    "current_value": "ondemand",
+                    "recommended_value": "performance",
+                    "compliance": False,
+                    "severity": "warning",
+                    "score_impact": 10,
+                },
+            ],
+            "memory": [
+                {
+                    "item": "vm.swappiness",
+                    "category": "memory",
+                    "current_value": "60",
+                    "recommended_value": "1",
+                    "compliance": False,
+                    "severity": "critical",
+                    "score_impact": 25,
+                },
+                {
+                    "item": "vm.dirty_ratio",
+                    "category": "memory",
+                    "current_value": "15",
+                    "recommended_value": "15",
+                    "compliance": True,
+                    "severity": "warning",
+                    "score_impact": 8,
+                },
+            ],
+        }
+    return {
+        "metadata": {
+            "scan_id": scan_id,
+            "timestamp": timestamp,
+        },
+        "server_info": {
+            "hostname": hostname,
+        },
+        "scan_results": items,
+        "compliance": {
+            "overall_score": overall_score,
+        },
+    }
+
+
+@pytest.fixture
+def detector(tmp_path):
+    """Create a DriftDetector with temporary history dir."""
+    return DriftDetector(history_dir=str(tmp_path / "history"))
+
+
+class TestDriftDetector:
+    """Test DriftDetector save/load/compare functionality."""
+
+    def test_save_and_load(self, detector):
+        report = _make_report()
+        path = detector.save_scan(report)
+
+        assert os.path.exists(path)
+
+        loaded = detector.get_previous("test-host")
+        assert loaded is not None
+        assert loaded["metadata"]["scan_id"] == "scan-001"
+
+    def test_no_previous(self, detector):
+        assert detector.get_previous("nonexistent") is None
+
+    def test_history(self, detector):
+        r1 = _make_report(scan_id="s1", timestamp="2024-03-07T10:00:00Z")
+        r2 = _make_report(scan_id="s2", timestamp="2024-03-07T11:00:00Z")
+
+        detector.save_scan(r1)
+        detector.save_scan(r2)
+
+        history = detector.get_history("test-host")
+        assert len(history) == 2
+        # Most recent first
+        assert history[0]["scan_id"] == "s2"
+
+    def test_compare_no_drift(self, detector):
+        report = _make_report()
+        drift = detector.compare(report, report)
+
+        assert drift["summary"]["has_drift"] is False
+        assert drift["summary"]["changed"] == 0
+        assert drift["score_change"]["delta"] == 0
+
+    def test_compare_value_changed(self, detector):
+        prev_items = {
+            "memory": [
+                {
+                    "item": "vm.swappiness",
+                    "category": "memory",
+                    "current_value": "60",
+                    "recommended_value": "1",
+                    "compliance": False,
+                    "severity": "critical",
+                    "score_impact": 25,
+                },
+            ],
+        }
+        cur_items = {
+            "memory": [
+                {
+                    "item": "vm.swappiness",
+                    "category": "memory",
+                    "current_value": "1",
+                    "recommended_value": "1",
+                    "compliance": True,
+                    "severity": "critical",
+                    "score_impact": 25,
+                },
+            ],
+        }
+        prev = _make_report(items=prev_items, overall_score=50)
+        cur = _make_report(items=cur_items, overall_score=75)
+
+        drift = detector.compare(cur, prev)
+
+        assert drift["summary"]["has_drift"] is True
+        assert drift["summary"]["changed"] == 1
+        assert drift["summary"]["improved"] == 1
+        assert drift["score_change"]["delta"] == 25
+
+        item = drift["items"][0]
+        assert item["item"] == "vm.swappiness"
+        assert item["drift_type"] == "improved"
+        assert item["previous_value"] == "60"
+        assert item["current_value"] == "1"
+
+    def test_compare_degraded(self, detector):
+        prev_items = {
+            "cpu": [
+                {
+                    "item": "scaling_governor",
+                    "category": "cpu",
+                    "current_value": "performance",
+                    "recommended_value": "performance",
+                    "compliance": True,
+                    "severity": "warning",
+                    "score_impact": 10,
+                },
+            ],
+        }
+        cur_items = {
+            "cpu": [
+                {
+                    "item": "scaling_governor",
+                    "category": "cpu",
+                    "current_value": "powersave",
+                    "recommended_value": "performance",
+                    "compliance": False,
+                    "severity": "warning",
+                    "score_impact": 10,
+                },
+            ],
+        }
+        prev = _make_report(items=prev_items, overall_score=90)
+        cur = _make_report(items=cur_items, overall_score=80)
+
+        drift = detector.compare(cur, prev)
+
+        assert drift["summary"]["degraded"] == 1
+        assert drift["items"][0]["drift_type"] == "degraded"
+        assert drift["score_change"]["delta"] == -10
+
+    def test_compare_added_removed(self, detector):
+        prev_items = {
+            "cpu": [
+                {
+                    "item": "scaling_governor",
+                    "category": "cpu",
+                    "current_value": "performance",
+                    "recommended_value": "performance",
+                    "compliance": True,
+                    "severity": "warning",
+                    "score_impact": 10,
+                },
+            ],
+        }
+        cur_items = {
+            "memory": [
+                {
+                    "item": "vm.swappiness",
+                    "category": "memory",
+                    "current_value": "1",
+                    "recommended_value": "1",
+                    "compliance": True,
+                    "severity": "critical",
+                    "score_impact": 25,
+                },
+            ],
+        }
+        prev = _make_report(items=prev_items)
+        cur = _make_report(items=cur_items)
+
+        drift = detector.compare(cur, prev)
+
+        assert drift["summary"]["added"] == 1
+        assert drift["summary"]["removed"] == 1
+
+        types = {i["drift_type"] for i in drift["items"]}
+        assert "added" in types
+        assert "removed" in types
+
+    def test_save_creates_latest_symlink(self, detector):
+        report = _make_report()
+        detector.save_scan(report)
+
+        host_dir = detector._host_dir("test-host")
+        latest = host_dir / "latest.json"
+        assert latest.is_symlink()
+
+        with open(latest) as f:
+            data = json.load(f)
+        assert data["metadata"]["scan_id"] == "scan-001"
+
+    def test_multiple_saves_update_latest(self, detector):
+        r1 = _make_report(scan_id="s1")
+        r2 = _make_report(scan_id="s2")
+
+        detector.save_scan(r1)
+        detector.save_scan(r2)
+
+        loaded = detector.get_previous("test-host")
+        assert loaded["metadata"]["scan_id"] == "s2"
+
+    def test_history_limit(self, detector):
+        for i in range(15):
+            r = _make_report(scan_id=f"s{i:03d}")
+            detector.save_scan(r)
+
+        history = detector.get_history("test-host", limit=5)
+        assert len(history) == 5

--- a/tests/test_drift_api.py
+++ b/tests/test_drift_api.py
@@ -1,0 +1,319 @@
+"""Tests for drift and remediation API endpoints."""
+
+import json
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from aggregator.app import create_app
+from aggregator.config import Settings
+from aggregator.database import Database
+
+
+def _settings():
+    return Settings(
+        host="127.0.0.1",
+        port=8443,
+        debug=False,
+        db_path=":memory:",
+        api_keys=[],
+        cors_origins=["*"],
+        rate_limit_per_minute=1000,
+        retention_days=30,
+    )
+
+
+def _sample_report(score=85, swappiness="60"):
+    return {
+        "metadata": {
+            "version": "1.0.0",
+            "agent_version": "0.1.0",
+            "scan_id": "test-scan-001",
+            "timestamp": "2024-03-07T07:48:00Z",
+        },
+        "server_info": {
+            "hostname": "test-host",
+            "role": {"detected": "compute"},
+            "region": "seoul",
+        },
+        "scan_results": {
+            "memory": [
+                {
+                    "item": "vm.swappiness",
+                    "category": "memory",
+                    "description": "스왑 사용 적극성 설정",
+                    "current_value": swappiness,
+                    "recommended_value": "1",
+                    "compliance": swappiness == "1",
+                    "severity": "critical",
+                    "score_impact": 25,
+                    "remediation": {
+                        "command": "sysctl -w vm.swappiness=1",
+                        "persistent": "echo 'vm.swappiness = 1' >> /etc/sysctl.conf",
+                        "requires_reboot": False,
+                    },
+                },
+            ],
+        },
+        "compliance": {
+            "overall_score": score,
+            "severity_summary": {"critical": 1, "warning": 0, "info": 0},
+        },
+    }
+
+
+@pytest.fixture
+def app():
+    application = create_app(_settings())
+    application.state.db = Database(":memory:")
+    application.state.db.connect()
+    yield application
+    application.state.db.close()
+
+
+@pytest.mark.anyio
+class TestDriftAPI:
+    """Test drift API endpoints."""
+
+    async def test_compare_reports(self, app):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            prev = _sample_report(score=50, swappiness="60")
+            cur = _sample_report(score=85, swappiness="1")
+
+            resp = await client.post(
+                "/api/v1/drift/compare",
+                json={
+                    "current_report": cur,
+                    "previous_report": prev,
+                },
+            )
+            assert resp.status_code == 200
+            data = resp.json()["data"]
+            assert data["summary"]["has_drift"] is True
+            assert data["summary"]["improved"] == 1
+            assert data["score_change"]["delta"] == 35
+
+    async def test_compare_by_server_id(self, app):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            # Submit two reports
+            await client.post(
+                "/api/v1/reports",
+                json={
+                    "server_id": "web-01",
+                    "report": _sample_report(score=50, swappiness="60"),
+                },
+            )
+            await client.post(
+                "/api/v1/reports",
+                json={
+                    "server_id": "web-01",
+                    "report": _sample_report(score=85, swappiness="1"),
+                },
+            )
+
+            resp = await client.post(
+                "/api/v1/drift/compare",
+                json={"server_id": "web-01"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()["data"]
+            assert data["summary"]["has_drift"] is True
+
+    async def test_compare_insufficient_data(self, app):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            await client.post(
+                "/api/v1/reports",
+                json={
+                    "server_id": "lonely-01",
+                    "report": _sample_report(),
+                },
+            )
+
+            resp = await client.post(
+                "/api/v1/drift/compare",
+                json={"server_id": "lonely-01"},
+            )
+            assert resp.status_code == 404
+
+    async def test_get_drift(self, app):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            await client.post(
+                "/api/v1/reports",
+                json={
+                    "server_id": "web-02",
+                    "report": _sample_report(score=50, swappiness="60"),
+                },
+            )
+            await client.post(
+                "/api/v1/reports",
+                json={
+                    "server_id": "web-02",
+                    "report": _sample_report(score=85, swappiness="1"),
+                },
+            )
+
+            resp = await client.get("/api/v1/drift/web-02")
+            assert resp.status_code == 200
+            data = resp.json()["data"]
+            assert data["summary"]["has_drift"] is True
+
+    async def test_get_drift_single_report(self, app):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            await client.post(
+                "/api/v1/reports",
+                json={
+                    "server_id": "single-01",
+                    "report": _sample_report(),
+                },
+            )
+
+            resp = await client.get("/api/v1/drift/single-01")
+            assert resp.status_code == 200
+            data = resp.json()["data"]
+            assert data["has_drift"] is False
+
+    async def test_get_drift_not_found(self, app):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/v1/drift/nonexistent")
+            assert resp.status_code == 404
+
+    async def test_drift_history(self, app):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            for score in [50, 60, 70, 80]:
+                await client.post(
+                    "/api/v1/reports",
+                    json={
+                        "server_id": "trend-01",
+                        "report": _sample_report(score=score),
+                    },
+                )
+
+            resp = await client.get("/api/v1/drift/trend-01/history")
+            assert resp.status_code == 200
+            data = resp.json()["data"]
+            assert len(data["history"]) == 4
+            assert data["trend"] == "improving"
+
+
+@pytest.mark.anyio
+class TestRemediationAPI:
+    """Test remediation API endpoints."""
+
+    async def test_generate_from_report(self, app):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/v1/remediation/generate",
+                json={"report": _sample_report(swappiness="60")},
+            )
+            assert resp.status_code == 200
+            data = resp.json()["data"]
+            assert data["total_fixes"] == 1
+            assert "script" in data
+            assert "vm.swappiness" in data["script"]
+
+    async def test_generate_from_server_id(self, app):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            await client.post(
+                "/api/v1/reports",
+                json={
+                    "server_id": "fix-01",
+                    "report": _sample_report(swappiness="60"),
+                },
+            )
+
+            resp = await client.post(
+                "/api/v1/remediation/generate",
+                json={"server_id": "fix-01"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()["data"]
+            assert data["total_fixes"] == 1
+
+    async def test_generate_with_filter(self, app):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            # Compliant report — no fixes needed
+            resp = await client.post(
+                "/api/v1/remediation/generate",
+                json={
+                    "report": _sample_report(swappiness="1"),
+                    "severities": ["critical"],
+                },
+            )
+            assert resp.status_code == 200
+            data = resp.json()["data"]
+            assert data["total_fixes"] == 0
+
+    async def test_generate_no_data(self, app):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/v1/remediation/generate",
+                json={},
+            )
+            assert resp.status_code == 400
+
+    async def test_get_remediation(self, app):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            await client.post(
+                "/api/v1/reports",
+                json={
+                    "server_id": "rem-01",
+                    "report": _sample_report(swappiness="60"),
+                },
+            )
+
+            resp = await client.get("/api/v1/remediation/rem-01")
+            assert resp.status_code == 200
+            data = resp.json()["data"]
+            assert data["total_non_compliant"] == 1
+            assert data["items"][0]["item"] == "vm.swappiness"
+
+    async def test_get_remediation_not_found(self, app):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/v1/remediation/nonexistent")
+            assert resp.status_code == 404
+
+    async def test_get_remediation_severity_filter(self, app):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            await client.post(
+                "/api/v1/reports",
+                json={
+                    "server_id": "sev-01",
+                    "report": _sample_report(swappiness="60"),
+                },
+            )
+
+            # Filter by warning — should find nothing (only critical)
+            resp = await client.get(
+                "/api/v1/remediation/sev-01?severity=warning"
+            )
+            assert resp.status_code == 200
+            data = resp.json()["data"]
+            assert data["total_non_compliant"] == 0

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -1,0 +1,198 @@
+"""Tests for RemediationGenerator."""
+
+import pytest
+
+from infra_auditor.remediation import RemediationGenerator
+
+
+def _make_report(items=None, hostname="test-host", role="compute"):
+    """Build a minimal report for remediation testing."""
+    if items is None:
+        items = {
+            "memory": [
+                {
+                    "item": "vm.swappiness",
+                    "category": "memory",
+                    "description": "스왑 사용 적극성 설정",
+                    "current_value": "60",
+                    "recommended_value": "1",
+                    "compliance": False,
+                    "severity": "critical",
+                    "score_impact": 25,
+                    "remediation": {
+                        "command": "sysctl -w vm.swappiness=1",
+                        "persistent": "echo 'vm.swappiness = 1' >> /etc/sysctl.conf",
+                        "requires_reboot": False,
+                    },
+                },
+                {
+                    "item": "vm.dirty_ratio",
+                    "category": "memory",
+                    "description": "더티 페이지 비율 상한",
+                    "current_value": "15",
+                    "recommended_value": "15",
+                    "compliance": True,
+                    "severity": "warning",
+                    "score_impact": 8,
+                    "remediation": {
+                        "command": "sysctl -w vm.dirty_ratio=15",
+                        "persistent": "",
+                        "requires_reboot": False,
+                    },
+                },
+            ],
+            "cpu": [
+                {
+                    "item": "scaling_governor",
+                    "category": "cpu",
+                    "description": "CPU 주파수 조절 정책",
+                    "current_value": "ondemand",
+                    "recommended_value": "performance",
+                    "compliance": False,
+                    "severity": "warning",
+                    "score_impact": 10,
+                    "remediation": {
+                        "command": "echo performance | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor",
+                        "persistent": "",
+                        "requires_reboot": False,
+                    },
+                },
+                {
+                    "item": "max_cstate",
+                    "category": "cpu",
+                    "description": "CPU C-state 최대 깊이",
+                    "current_value": "9",
+                    "recommended_value": "1",
+                    "compliance": False,
+                    "severity": "warning",
+                    "score_impact": 8,
+                    "remediation": {
+                        "command": "",
+                        "persistent": "GRUB_CMDLINE에 intel_idle.max_cstate=1 추가",
+                        "requires_reboot": True,
+                    },
+                },
+            ],
+        }
+
+    return {
+        "server_info": {"hostname": hostname, "role": role},
+        "scan_results": items,
+        "compliance": {"overall_score": 50},
+    }
+
+
+class TestRemediationGenerator:
+    """Test remediation script generation."""
+
+    def test_generate_basic(self):
+        gen = RemediationGenerator()
+        result = gen.generate(_make_report())
+
+        assert result["total_fixes"] == 3  # 3 non-compliant
+        assert result["hostname"] == "test-host"
+        assert result["role"] == "compute"
+        assert result["reboot_required"] is True
+        assert len(result["items"]) == 3
+        assert result["script"]  # Non-empty script
+
+    def test_generate_script_content(self):
+        gen = RemediationGenerator()
+        result = gen.generate(_make_report())
+        script = result["script"]
+
+        assert "#!/usr/bin/env bash" in script
+        assert "DRY_RUN" in script
+        assert "BACKUP_DIR" in script
+        assert "apply_sysctl" in script
+        assert "vm.swappiness" in script
+
+    def test_generate_all_compliant(self):
+        items = {
+            "memory": [
+                {
+                    "item": "vm.swappiness",
+                    "category": "memory",
+                    "current_value": "1",
+                    "recommended_value": "1",
+                    "compliance": True,
+                    "severity": "critical",
+                    "remediation": {"command": "", "persistent": "", "requires_reboot": False},
+                },
+            ],
+        }
+        gen = RemediationGenerator()
+        result = gen.generate(_make_report(items=items))
+
+        assert result["total_fixes"] == 0
+        assert result["script"] == ""
+        assert result["items"] == []
+
+    def test_filter_by_severity(self):
+        gen = RemediationGenerator()
+        result = gen.generate(
+            _make_report(),
+            severities=["critical"],
+        )
+
+        assert result["total_fixes"] == 1
+        assert result["items"][0]["item"] == "vm.swappiness"
+
+    def test_filter_by_category(self):
+        gen = RemediationGenerator()
+        result = gen.generate(
+            _make_report(),
+            categories=["cpu"],
+        )
+
+        assert result["total_fixes"] == 2
+        items = {i["item"] for i in result["items"]}
+        assert "scaling_governor" in items
+        assert "max_cstate" in items
+
+    def test_fix_type_classification(self):
+        gen = RemediationGenerator()
+        result = gen.generate(_make_report())
+
+        fix_types = {i["item"]: i["fix_type"] for i in result["items"]}
+        assert fix_types["vm.swappiness"] == "sysctl"
+        assert fix_types["scaling_governor"] == "command"
+
+    def test_generate_single_fix(self):
+        item = {
+            "remediation": {
+                "command": "sysctl -w vm.swappiness=1",
+            },
+        }
+        cmd = RemediationGenerator.generate_single_fix(item)
+        assert cmd == "sysctl -w vm.swappiness=1"
+
+    def test_generate_single_fix_no_command(self):
+        item = {"remediation": {"command": ""}}
+        cmd = RemediationGenerator.generate_single_fix(item)
+        assert cmd is None
+
+    def test_role_dict_handling(self):
+        """Handle role as dict (from server_info)."""
+        report = _make_report()
+        report["server_info"]["role"] = {"detected": "control"}
+
+        gen = RemediationGenerator()
+        result = gen.generate(report)
+        assert result["role"] == "control"
+
+    def test_script_has_dry_run(self):
+        gen = RemediationGenerator()
+        result = gen.generate(_make_report())
+        script = result["script"]
+
+        assert "--dry-run" in script
+        assert "DRY_RUN=false" in script
+
+    def test_script_has_backup(self):
+        gen = RemediationGenerator()
+        result = gen.generate(_make_report())
+        script = result["script"]
+
+        assert "BACKUP_DIR" in script
+        assert "backup_file" in script


### PR DESCRIPTION
## Summary
Phase 7 구현: 스캔 결과 비교(Drift Detection)와 자동 수정 스크립트 생성(Remediation)

## Changes

### 새 모듈
- **`infra_auditor/drift.py`** — DriftDetector
  - 스캔 결과를 `~/.infra-auditor/history/`에 호스트별 JSON 파일로 저장
  - 현재/이전 스캔 비교: improved, degraded, changed, added, removed 분류
  - compliance score delta 추적

- **`infra_auditor/remediation.py`** — RemediationGenerator
  - 비준수 항목 → 셸 스크립트 자동 생성
  - sysctl 설정은 `apply_sysctl`/`persist_sysctl` 헬퍼 사용
  - 백업 디렉토리 + 변경 로그 자동 생성
  - `--dry-run` 모드 지원

### CLI 확장
- `scan`: 스캔 시 자동 히스토리 저장 + summary에서 drift 표시
- `drift`: 전용 drift 비교 명령어
- `remediate`: 수정 스크립트 생성 (`--severity`, `--category` 필터)

### Aggregator API (5개 새 엔드포인트)
- `POST /api/v1/drift/compare` — 두 리포트 비교 (inline 또는 server_id)
- `GET /api/v1/drift/{server_id}` — 서버 최신 drift
- `GET /api/v1/drift/{server_id}/history` — compliance score 트렌드
- `POST /api/v1/remediation/generate` — 수정 스크립트 생성
- `GET /api/v1/remediation/{server_id}` — 비준수 항목 조회

### 테스트
- 134개 전체 통과 (기존 93 + 신규 41)
- `test_drift.py`: DriftDetector 저장/로드/비교
- `test_remediation.py`: 스크립트 생성, 필터, 분류
- `test_drift_api.py`: API 엔드포인트 통합 테스트

Closes #9